### PR TITLE
make require() paths more consistent in Utils.loadNamespace

### DIFF
--- a/concord/utils.lua
+++ b/concord/utils.lua
@@ -31,6 +31,10 @@ function Utils.loadNamespace(pathOrFiles, namespace)
             error("bad argument #1 to 'loadNamespace' (path '"..pathOrFiles.."' not found)", 2)
        end
 
+       -- normalizes the path to use dots instead of slashes
+       -- this is more friendly to require
+       local friendlyPath = pathOrFiles:gsub("%/", ".")
+
        local files = love.filesystem.getDirectoryItems(pathOrFiles)
 
        for _, file in ipairs(files) do
@@ -38,12 +42,12 @@ function Utils.loadNamespace(pathOrFiles, namespace)
 
             if isFile then
                  local name = file:sub(1, #file - 4)
-                 local path = pathOrFiles.."."..name
+                 local path = friendlyPath.."."..name
 
                  local value = require(path)
                  if namespace then namespace[name] = value end
             else
-                 local value = require(pathOrFiles.."."..file)
+                 local value = require(friendlyPath.."."..file)
 				 if namespace then namespace[file] = value end
             end
        end


### PR DESCRIPTION
Passing a subdirectory to the function in question, `ecs/systems` for example, would have led the function to `require` paths with mixed semantics (`ecs/systems.collision`, `ecs/systems.movement`, etc); this seems fine by itself, until you notice that `require` treats `ecs/systems.collision` and `ecs.systems.collision` as different "modules," thus circumventing `require`'s duplicate-load-protection... in particular, these would give you tables that look the same, structurally, but in fact have different identities! As a result, if you had called, for example, `world:getSystem(require("ecs.systems.collision"))`, you would have gotten a nil value, which is a bit confusing if you know the system has been otherwise loaded and added to the world.